### PR TITLE
Checks for MX, A, and AAAA DNS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ composer require nojacko/email-validator:~1.0
 ## Usage
 ### Generalised Functions
 * ```isValid($email)``` Runs all the tests within this library. Returns true or false.
-* ```isSendable($email)``` Checks isEmail, isExample and hasMx. Returns true or false.
+* ```isSendable($email)``` Checks isEmail, isExample and hasDNS. Returns true or false.
 
 
 ### Specific Functions
@@ -32,7 +32,7 @@ If you want more control, use these functions seperately.
 * ```isExample($email)```
 * ```isDisposable($email)```
 * ```isRole($email)```
-* ```hasMx($email)```
+* ```hasDNS($email)```
 
 These functions take a single argument (an email address) and return:
 
@@ -68,9 +68,9 @@ $validator->isRole('example@example.com');              // false
 $validator->isRole('abuse@example.com');                // true
 $validator->isRole('example.com');                      // null
 
-$validator->hasMx('example@example.com');               // false
-$validator->hasMx('example@google.com');                // true
-$validator->hasMx('example.com');                       // null
+$validator->hasDNS('example@example.com');               // false
+$validator->hasDNS('example@google.com');                // true
+$validator->hasDNS('example.com');                       // null
 ```
 
 ## Contribute

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -81,7 +81,7 @@ class Validator
         }
 
         // Does it have an MX record?
-        if (! $this->hasMx($email)) {
+        if (! $this->hasDNS($email)) {
             return false;
         }
 
@@ -89,7 +89,7 @@ class Validator
     }
 
     /**
-     * Validate an email address using isEmail, isExample and hasMx.
+     * Validate an email address using isEmail, isExample and hasDNS.
      *
      * @param string $email Address
      * @return boolean
@@ -107,7 +107,7 @@ class Validator
         }
 
         // Does it have an MX record?
-        if (! $this->hasMx($email)) {
+        if (! $this->hasDNS($email)) {
             return false;
         }
 
@@ -229,12 +229,12 @@ class Validator
     }
 
     /**
-     * Test email address for MX records
+     * Test email address for MX, A, or AAAA records
      *
      * @param string $email Address
      * @return boolean|null
      */
-    public function hasMx($email)
+    public function hasDNS($email)
     {
         if (! $this->isEmail($email)) {
             return null;
@@ -243,7 +243,7 @@ class Validator
         $hostname = $this->hostnameFromEmail($email);
 
         if ($hostname) {
-            return checkdnsrr($hostname, 'MX');
+            return checkdnsrr($hostname, 'MX') || checkdnsrr($hostname, 'A') || checkdnsrr($hostname, 'AAAA');
         }
 
         return null;


### PR DESCRIPTION
Changed `hasMx` to `hasDNS` to reflect the semantic check for A and AAAA records in `Validator.php`.
Updated **README.md** with `hasDNS` instead of `hasMx`.

This is to reflect the fact that some email domains have no MX records but have an A or AAAA record.
I borrowed this idea from [egulias/EmailValidator](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/DNSCheckValidation.php) source.
